### PR TITLE
Fix error ("Expecting value: line 1....") on /planning endpoint

### DIFF
--- a/epitech_api_flask.py
+++ b/epitech_api_flask.py
@@ -58,7 +58,7 @@ def planning():
             log_file("Intra replied in %s seconds" %r.elapsed)
         if len(r.text) < 2:
             return (json.dumps({"error":{"message":"Epitech API returned an empty response", "code":500}})), 500
-        planning = json.loads(clean_json(r.text))
+        planning = json.loads(r.text)
         filtered_planning = get_classes_by_status(planning, get)
         return json.dumps(filtered_planning)
     except Exception as e:


### PR DESCRIPTION
Comme l'api d'Epitech retourne du json valide il n'y a plus besoin de retirer les 31 premiers caracteres de `r.text` avec l'appel a la fonction `clean_json`.