### PR TITLE
Fixed modules route not returning valid JSON

### DIFF
--- a/api_parser.py
+++ b/api_parser.py
@@ -80,4 +80,4 @@ def get_modules(html_raw):
     haystack = "window.user = $.extend(window.user || {}, {"
     pos = html_raw.find(haystack)
     pos2 = html_raw.find("notes: [")
-    return "{"+html_raw[pos+len(haystack):pos2 -4]+"}"
+    return html_raw[pos+len(haystack)+11:pos2 -4]


### PR DESCRIPTION
Same problem as with marks, the data returned was not valid JSON. Removed encapsulation and made the route return an array.